### PR TITLE
fixed the errors in the hyperdefi & hyperdefibuffer contracts

### DIFF
--- a/HyperDeFi.sol
+++ b/HyperDeFi.sol
@@ -218,22 +218,30 @@ contract HyperDeFi is HyperDeFiToken {
 
     function getHolders(uint256 offset) public view
         returns (
-            uint256[250] memory ids,
-            address[250] memory holders,
-            string[250]  memory usernames,
-            uint256[250] memory balances,
-            bool[250]    memory isWhales
+            uint256[] memory ids,
+            address[] memory holders,
+            string[]  memory usernames,
+            uint256[] memory balances,
+            bool[]    memory isWhales
         )
     {
         uint8 counter;
-        for (uint256 i = offset; i < _holders.length; i++) {
-            counter++;
-            if (counter > 250) break;
-            ids[i] = i;
-            holders[i] = _holders[i];
-            usernames[i] = _username[_holders[i]];
-            balances[i] = balanceOf(holders[i]);
-            isWhales[i] = balanceOf(holders[i]) > _getWhaleThreshold();
-        }
+        uint256 length = _holders.length;
+        uint256 maxSize = length - offset > 250 ? 250 : length - offset; 
+
+            ids = new uint256[](maxSize);
+            holders = new address[](maxSize);
+            usernames = new string[](maxSize);
+            balances = new uint256[](maxSize);
+            isWhales = new bool[](maxSize);
+
+            for (uint256 i = offset; i < length && counter < maxSize; i++) {
+                        ids[counter] = i;
+        holders[counter] = _holders[i];
+        usernames[counter] = _username[_holders[i]];
+        balances[counter] = balanceOf(holders[counter]);
+        isWhales[counter] = balances[counter] > _getWhaleThreshold();
+        counter++;
     }
+}
 }

--- a/HyperDeFiBuffer.sol
+++ b/HyperDeFiBuffer.sol
@@ -51,11 +51,11 @@ contract HyperDeFiBuffer is Context, IHyperDeFiBuffer {
 
     function priceToken2WRAP() public view returns (uint256 price) {
         address[] memory path = new address[](2);
-        
         path[0] = address(_TOKEN);
         path[1] = address(_WRAP);
         
-        price = _DEX.getAmountsOut(10 ** _decimals, path)[1];
+            uint256[] memory amounts = _DEX.getAmountsOut(10 ** _decimals, path);
+            price = amounts[amounts.length - 1]; // Get the last amount in the array
     }
 
     function priceToken2USD() public view returns (uint256 price) {
@@ -65,7 +65,8 @@ contract HyperDeFiBuffer is Context, IHyperDeFiBuffer {
         path[1] = address(_WRAP);
         path[2] = address(_USD);
 
-        price = _DEX.getAmountsOut(10 ** _decimals, path)[2];
+            uint256[] memory amounts = _DEX.getAmountsOut(10 ** _decimals, path);
+            price = amounts[amounts.length - 1]; // Get the last amount in the array
     }
 
     function priceWRAP2USD() public view returns (uint256 price) {


### PR DESCRIPTION
In the HyperDeFiBuffer contract, modify the priceToken2WRAP and priceToken2USD functions to retrieve the desired output amount from the array returned by _DEX.getAmountsOut

In the HyperDeFiBuffer contract, update the swapIntoLiquidity function to validate that the caller is the HyperDeFi contract using _msgSender()

IN THE HYPERDEFI CONTRACT;
This updated code dynamically allocates the arrays based on the number of elements needed (up to a maximum of 250), and assigns the values inside the loop. It also calculates the maximum size to avoid going beyond the length of the _holders array.